### PR TITLE
[#44] 포트폴리오 예측 DAG 시간 변경 (오후 8시 -> 새벽 12시 반)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,3 @@
 
 # Architecture
 ![image](https://github.com/user-attachments/assets/b60187fb-e13f-4100-86ee-f62946d563a5)
-

--- a/airflow/dags/prophesy_n_make_decision_dag.py
+++ b/airflow/dags/prophesy_n_make_decision_dag.py
@@ -22,7 +22,7 @@ prophesy_n_make_decision_dag = DAG(
     description="prophesy current portfolio's trend and make decision of purchase or sell",
     start_date=datetime.datetime(2024, 7, 1, tzinfo=kst),
     # 장 종료 후 금일 종가로 내일 장전 시간외 매수로 예약 매수를 걸어 놓는다.
-    schedule_interval="0 20 * * *",
+    schedule_interval="30 0 * * *",
     # schedule_interval=None,
 )
 


### PR DESCRIPTION
## Title
- postpone prophet time from 20:00 -> 00:30

## Description
- yfinance가 즉각적으로 해당 장마감 이후의 종가를 가져오지 못함.
- 금일 종목 종가만 다른 금융 API로 가져와서 yfinance에 이어붙이면 되긴 하지만 그럼 ETF와 일반 주식 종목을 구분해야 하고 복잡함.
- 가장 간단한 방법인 00시를 넘기게 해서 날짜 다르게 해서 해결

## Linked Issues
- resolved #44 
