### PR TITLE
[#[44] yfinance 금일 종가 오류 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,3 @@
 
 # Architecture
 ![image](https://github.com/user-attachments/assets/b60187fb-e13f-4100-86ee-f62946d563a5)
-

--- a/prophecy.py
+++ b/prophecy.py
@@ -95,7 +95,8 @@ class ProphetModel:
         self.stock_symbol = stock_symbol
         self.start_date = start_date
         KST = timezone(timedelta(hours=9))
-        self.end_date = datetime.now(KST).strftime('%Y-%m-%d')
+        end_datetime = datetime.now(KST) + timedelta(days=1)
+        self.end_date = end_datetime.strftime('%Y-%m-%d')
 
         self.stock_data = yf.download(stock_symbol, start=start_date, end=end_date)
         self.stock_data = self.stock_data.asfreq('B')


### PR DESCRIPTION
## Title
- yf today close

## Description
- yfinance가 장이 끝나지 않았을 때 종가를 못가져오는 것이 아니었음;;
  - 종가를 구할 때 end_date 파라미터를 +1로 줘야 진행장의 종가를 알 수 있었음.. 그냥 그렇게하면 잘 됨
  - 기존에 못했던 것은 airflow의 next_ds를 사용하지 않아 뒤쳐진 데이터를 사용했기 때문도 있는 듯

## Linked Issues
- resolved #44 
