### PR TITLE
[#40] 포트폴리오 업데이트 DAG 수정

### DIFF
--- a/airflow/dags/asset_check_n_distribution_dag.py
+++ b/airflow/dags/asset_check_n_distribution_dag.py
@@ -6,7 +6,7 @@ from airflow import DAG
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator, BranchPythonOperator
 from asset_update import check_balance, check_portfolio, distribute_asset
-from common.calc_business_day import check_date
+from common.calc_business_day import check_auto_payment_date
 
 # Configure logger.py correctly
 # Logger
@@ -27,7 +27,7 @@ asset_check_n_distribution_dag = DAG(
 
 check_date = BranchPythonOperator(
     task_id='check_date',
-    python_callable=check_date,
+    python_callable=check_auto_payment_date,
     op_kwargs={"next_task_name": "check_balance", "use_next_ds": True},
     dag=asset_check_n_distribution_dag,
     provide_context=True,

--- a/airflow/plugins/asset_update.py
+++ b/airflow/plugins/asset_update.py
@@ -81,9 +81,9 @@ def check_portfolio(**kwargs):
     )
     portfolio_rows = response.json()
 
-    # 2. 아직 구매 및 할당되지 않는 후보 종목들의 종목 id를 구한다.
+    # 2. 아직 예산이 할당되지 않았고 매수 신청을 하지 않은 후보 종목들의 종목 id를 구한다.
     candidate_portfolio_rows = list(filter(
-        lambda row: row["month_purchase_flag"] is False and row["month_budget"] == 0, portfolio_rows
+        lambda row: row["order_status"] == "N" and row["month_budget"] == 0, portfolio_rows
     ))
 
     if len(candidate_portfolio_rows) > 0:

--- a/airflow/plugins/common/calc_business_day.py
+++ b/airflow/plugins/common/calc_business_day.py
@@ -35,7 +35,7 @@ def is_ktc_business_day(execution_date, is_next: bool = False):
     if is_next:
         curr_date = datetime.strptime(execution_date, "%Y-%m-%d").date()
     else:
-        curr_date = execution_date.strftime("%Y-%m-%d")
+        curr_date = execution_date.date()
 
 
     if curr_date.weekday() < 5 and is_holiday(curr_date) is False:
@@ -76,3 +76,76 @@ def check_date(execution_date: datetime, next_task_name: str, next_ds: str, use_
             f"run empty",
         )
         return 'task_empty'
+
+
+def check_auto_payment_date(execution_date: datetime, next_task_name: str, next_ds: str, use_next_ds: bool = False):
+    """자동이체 날 여부 확인
+    오늘이 자동이체 날 다음 영업일인지 확인하고 주어진 task를 실행할지 혹은 empty task를 실행할 지 결정한다.
+    한 달에 한 번만 수행해야하는 로직을 위한 검사이다.
+
+    Args:
+        execution_date (str): 실행시점
+        next_task_name (str): 날짜가 맞다면 수행할 다음 task
+
+    Returns:
+        next_task_name (str): 다음에 수행할 task의 이름으로 파라미터로 받은 next_task_name이 될 수 있도 empty_task가 될 수도 있다.
+
+    """
+    # 정상 영업일의 경우 다음 과정을 수행한다.
+    logger.info(
+            f"input execution_date is {execution_date} and next_ds is {next_ds}. next_ds type is {type(next_ds)}",
+        )
+
+    auto_payment_day: int = int(os.getenv("AUTO_PAYMENT_DAY", 10))
+
+    if use_next_ds is True:
+        run_date = next_ds
+        run_date = datetime.strptime(run_date, "%Y-%m-%d").date()
+    else:
+        run_date = execution_date
+
+    # 애초에 아직 자동이체일보다도(defautl: 10) 작은 날짜인 경우
+    if run_date.day < auto_payment_day:
+        logger.info(
+            f"today is not ready before auto_payment_day {auto_payment_day} run empty",
+        )
+        return 'task_empty'
+    # 자동이체일을 넘은 경우
+    else:
+        # 자동이체날 이후 가장 가까운 다음 영업일을 구한다. (자동이체날 정확하게 이체가 되지 않기 때문)
+        safe_payment_day = -1
+        year, month = run_date.year, run_date.month
+        for day in range(auto_payment_day + 1, 30):
+            curr_datetime = datetime(year, month, day)
+
+            if is_ktc_business_day(curr_datetime) is True:
+                logger.info(
+                    f"this month is {run_date.month}. and safe payment day is {curr_datetime}",
+                )
+                safe_payment_day = curr_datetime.day
+                break
+
+        assert safe_payment_day != -1, f"safe_payment_day should not be {safe_payment_day}"
+
+        # 오늘이 자동이체일 이후 가장 가까운 다음 영업일인 경우
+        # 예수금을 조회해 포트폴리오를 갱신한다.
+        if safe_payment_day == run_date.day:
+            logger.info(
+                f"today is the day! run next task {next_task_name}",
+            )
+            return next_task_name
+        else:
+            logger.info(
+            "today is not the day! run empty",
+            )
+            return 'task_empty'
+
+
+if __name__ == "__main__":
+
+    res = check_auto_payment_date(
+        execution_date=datetime(2024, 8, 10),
+        next_task_name="next",
+        next_ds="f",
+    )
+    print(res)

--- a/fastapi_server/repository/portfolio_repository_service.py
+++ b/fastapi_server/repository/portfolio_repository_service.py
@@ -55,6 +55,7 @@ class PortfolioRepositoryService:
             result.ratio = portfolio.ratio
             result.month_purchase_flag = portfolio.month_purchase_flag
             result.updated_at = portfolio.updated_at
+            result.order_status = portfolio.order_status
             # session.add(result)
             session.commit()
 


### PR DESCRIPTION
## Title
- fix portfolio update DAG

## Description
- portfolio update 로직을 수정한다
  - 포트폴리오에 예수금을 분배하는 작업을 한달에 한번만 수행할 수 있도록 로직을 변경하였다. 
  - 예수금 자동이체 다음 영업일을 찾아 그날 수행한다.
- portfolio에 new field. order_status를 추가하였다.
  - N: 예수금을 분배받지 못한 상태
  - O: 예약 매수 요청된 상태
  - S: 예약 매수 요청이 성공한 상태
  - F: 예약 매수 요청이 실패한 상태

## Linked Issues
- resolved #40
