### PR TITLE
[#51] 구매 로직 수정 (예약 주문 조회 추가)

### DIFF
--- a/airflow/dags/check_order_dag.py
+++ b/airflow/dags/check_order_dag.py
@@ -1,0 +1,56 @@
+import datetime
+import logging
+import pendulum
+
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from airflow.operators.python import PythonOperator, BranchPythonOperator
+from prophesy import prophesy_portfolio, execute_decisions
+from common.calc_business_day import check_date
+
+# Configure logger.py correctly
+# Logger
+logger = logging.getLogger("api_logger")
+
+# KST 시간
+kst = pendulum.timezone("Asia/Seoul")
+
+"""주문 확인
+예약 매수/매도 주문을 확인하고 각 종목들의 성공/실패에 따라 portfolio rows의 order_status를 update한다.
+
+1. 주문한 종목들 존재 여부 확인
+2. 한투 API에 조회하여 상태 확인
+3. db에 적용
+"""
+check_order_dag = DAG(
+    # DAG 식별자용 아이디
+    dag_id="check_order_dag",
+    description="check trade order and apply to db",
+    start_date=datetime.datetime(2024, 10, 13, tzinfo=kst),
+    schedule_interval="0 18 * * *",
+)
+
+# 주문한 종목이 있다면 status를 확인한다.
+check_order_exist = BranchPythonOperator(
+    task_id='check_order',
+    python_callable=check_order_exist,
+    op_kwargs={"next_task_name": "check_order"},
+    dag=check_order_dag,
+    provide_context=True,
+)
+
+# 주문 확인
+check_order = PythonOperator(
+    task_id="check_order",
+    python_callable=check_order,
+    provide_context=True,
+    dag=check_order_dag,
+)
+
+task_empty = EmptyOperator(
+    task_id='task_empty',
+    dag=check_order_dag
+)
+
+# 매매 주문 내역 확인하고 존재하면 상태 확인
+check_order_exist >> [check_order, task_empty]

--- a/airflow/dags/check_order_dag.py
+++ b/airflow/dags/check_order_dag.py
@@ -31,7 +31,7 @@ check_order_dag = DAG(
 
 # 주문한 종목이 있다면 status를 확인한다.
 check_order_exist = BranchPythonOperator(
-    task_id='check_order',
+    task_id='check_order_exist',
     python_callable=check_order_exist,
     op_kwargs={"next_task_name": "check_order"},
     dag=check_order_dag,

--- a/airflow/plugins/asset_update.py
+++ b/airflow/plugins/asset_update.py
@@ -4,7 +4,7 @@ import logging
 import dotenv
 import requests
 
-dotenv.load_dotenv(f"./config/PROD.env")
+dotenv.load_dotenv(f"/home/ubuntu/zed/auto_trade/config/prod.env")
 logger = logging.getLogger("api_logger")
 
 
@@ -70,45 +70,6 @@ def get_portfolio_rows():
 
     return portfolio_rows
 
-def check_order_exist(next_task_name: str, **kwargs):
-    """주문 확인
-    예약 매수/매도 주문한 종목들 여부를 확인한다.
-    1. 있을 때
-    - 한투 API에 조회
-    2. 없을 때
-    - 종료
-    """
-    # db에서 Portfolio table을 가져온다.
-    portfolio_rows = get_portfolio_rows()
-
-    # 매매 신청한 종목들을 구한다.
-    candidate_portfolio_rows = list(filter(
-        lambda row: row["order_status"] == "O", portfolio_rows
-    ))
-
-    if len(candidate_portfolio_rows) > 0:
-        kwargs['task_instance'].xcom_push(key='candidate_portfolio_rows', value=candidate_portfolio_rows)
-
-        logger.info(
-            next_task_name,
-        )
-        return "check_order"
-    else:
-        logger.info(
-            "run task_empty",
-        )
-        return "task_empty"
-
-def check_order(**kwargs):
-    # 1. 앞서 구한 주문한 종목 rows 가져오기
-    candidate_portfolio_rows = kwargs['task_instance'].xcom_pull(key='candidate_portfolio_rows')
-
-    # 2. 전체 orders를 받아온다.
-    # TODO: orders trader controller에 request해서 가져온 뒤에 확인하고 처리하는 로직 남음
-
-
-
-
 def check_portfolio(**kwargs):
     """포트폴리오 투자
     1. db에서 Portfolio table을 가져온다.
@@ -157,6 +118,7 @@ def distribute_asset(**kwargs):
     # 1. 앞서 구한 할당/구매 안한 포트폴리오 rows 가져오기
     candidate_portfolio_rows = kwargs['task_instance'].xcom_pull(key='candidate_portfolio_rows')
 
+    input_text = ""
     for candidate_portfolio_row in candidate_portfolio_rows:
         stock_symbol = candidate_portfolio_row["stock_symbol"]
         ratio = float(candidate_portfolio_row["ratio"])
@@ -176,5 +138,16 @@ def distribute_asset(**kwargs):
 
         if response.status_code is not 200:
             raise Exception(f"status_code is {response.status_code} !")
+
+        input_text += f"stock_symbol {stock_symbol}에 month_budget {update_dict['month_budget']}이 할당되었습니다.\n"
+
+    channel_id = os.getenv("DAILY_REPORT_CHANNEL")
+    response = requests.post(
+        url=f'http://{os.getenv("FASTAPI_SERVER_HOST")}:{os.getenv("FASTAPI_SERVER_PORT")}/v1/slackbot/send_message',
+        data=json.dumps({
+            "channel_id": channel_id,
+            "input_text": input_text,
+        }),
+    )
 
     return True

--- a/airflow/plugins/common/calc_business_day.py
+++ b/airflow/plugins/common/calc_business_day.py
@@ -96,7 +96,7 @@ def check_auto_payment_date(execution_date: datetime, next_task_name: str, next_
             f"input execution_date is {execution_date} and next_ds is {next_ds}. next_ds type is {type(next_ds)}",
         )
 
-    auto_payment_day: int = int(os.getenv("AUTO_PAYMENT_DAY", 10))
+    auto_payment_day: int = int(os.getenv("AUTO_PAYMENT_DAY", 11))
 
     if use_next_ds is True:
         run_date = next_ds
@@ -104,7 +104,7 @@ def check_auto_payment_date(execution_date: datetime, next_task_name: str, next_
     else:
         run_date = execution_date
 
-    # 애초에 아직 자동이체일보다도(defautl: 10) 작은 날짜인 경우
+    # 애초에 아직 자동이체일보다도(defautl: 11) 작은 날짜인 경우
     if run_date.day < auto_payment_day:
         logger.info(
             f"today is not ready before auto_payment_day {auto_payment_day} run empty",

--- a/airflow/plugins/common/calc_business_day.py
+++ b/airflow/plugins/common/calc_business_day.py
@@ -5,7 +5,7 @@ import holidays
 from datetime import datetime, timedelta, date
 
 
-dotenv.load_dotenv(f"./config/PROD.env")
+dotenv.load_dotenv(f"/home/ubuntu/zed/auto_trade/config/prod.env")
 logger = logging.getLogger("api_logger")
 
 

--- a/airflow/plugins/common/trader_key_update.py
+++ b/airflow/plugins/common/trader_key_update.py
@@ -3,7 +3,7 @@ import dotenv
 import requests
 
 
-dotenv.load_dotenv(f"./config/prod.env")
+dotenv.load_dotenv(f"/home/ubuntu/zed/auto_trade/config/prod.env")
 
 
 def update_trader_key():

--- a/airflow/plugins/prophesy.py
+++ b/airflow/plugins/prophesy.py
@@ -37,6 +37,10 @@ def prophesy_portfolio(**kwargs):
         row["stock_symbol"]: row["month_budget"]
         for row in portfolio_rows
     }
+    stock_symbol2order_status = {
+        row["stock_symbol"]: row["order_status"]
+        for row in portfolio_rows
+    }
     # 1. 주어진 종목들에 대한 경향 예측을 수행한다.
     response = requests.post(
         url=f'http://{os.getenv("FASTAPI_SERVER_HOST")}:{os.getenv("FASTAPI_SERVER_PORT")}/v1/trader/prophet',
@@ -52,6 +56,7 @@ def prophesy_portfolio(**kwargs):
         last_price, diff_rate = prophecy["last_price"], prophecy["diff_rate"]
         behavior = _get_behavior(
             diff_rate=diff_rate,
+            order_status=stock_symbol2order_status[stock_symbol],
             purchase_threshold=float(os.getenv("PURCHASE_THRESHOLD")),
             sell_threshold=float(os.getenv("SELL_THRESHOLD")),
         )
@@ -61,6 +66,7 @@ def prophesy_portfolio(**kwargs):
         )
 
     kwargs['task_instance'].xcom_push(key='portfolio_behavior_decisions', value=portfolio_behavior_decisions)
+    logger.info(f"portfolio_behavior_decisions: {portfolio_behavior_decisions}")
 
     return True
 
@@ -92,10 +98,10 @@ def execute_decisions(**kwargs):
                     })
                 )
 
-                # 구매는 다음 DAG에서 수행하므로 distribute DAG에서는 month_budget만 업데이트해준다.
+                # 구매는 다음 DAG에서 수행하므로 distribute DAG에서는 예약금과 order_status를 변경한다
                 update_dict = {
-                    "month_budget": month_budget - (ord_qty * last_price),
-                    "month_purchase_flag": True,
+                    "reserved_budget": ord_qty * last_price,
+                    "order_status": "O",
                 }
 
                 response = requests.put(
@@ -103,6 +109,7 @@ def execute_decisions(**kwargs):
                     data=json.dumps(update_dict),
                 )
                 logger.info(f"stock_symbol: {stock_symbol} - behavior {behavior}'s result has saved at db with {response.json()}")
+
 
         elif behavior == SELL:
             if ord_qty > 0:
@@ -124,6 +131,7 @@ def execute_decisions(**kwargs):
 
 def _get_behavior(
     diff_rate: float,
+    order_status: str,
     purchase_threshold: float,
     sell_threshold: float,
 ):
@@ -131,6 +139,7 @@ def _get_behavior(
 
     Args:
         diff_rate (float): 종목의 기울기를 의미한다. 동작 판별의 근거가 된다.
+        order_status (str): 매매 주문 상태
         purchase_threshold (float): 매수 기준점
         sell_threshold (float): 매도 기준점
 
@@ -139,105 +148,10 @@ def _get_behavior(
 
     """
     behavior = STAY
-    if diff_rate >= purchase_threshold:
+    # 종목 상태가 예약 매수가 진행된 적이 없거나 실패한 상태일 때 수행한다.
+    if diff_rate >= purchase_threshold and order_status in ["N", "F"]:
         behavior = PURCHASE
-    elif diff_rate <= sell_threshold:
+    elif diff_rate <= sell_threshold and order_status in ["N", "F"]:
         behavior = SELL
 
     return behavior
-
-
-def get_balance():
-    """
-    day+2 예수금을 이용한다.
-    구매해서 빠지지 않은 예수금이 있을 수 있기 때문.
-
-    Returns:
-        +day2_balance (int)
-
-    """
-    response = requests.post(
-        url=f'http://{os.getenv("FASTAPI_SERVER_HOST")}:{os.getenv("FASTAPI_SERVER_PORT")}/v1/trader/get_balance',
-    )
-
-    response_json = response.json()
-    balance = int(response_json["output"]["prvs_rcdl_excc_amt"])
-
-    return balance
-
-
-def check_portfolio(**kwargs):
-    """포트폴리오 투자
-    1. db에서 Portfolio table을 가져온다.
-        ex. [
-                {'updated_at': '2024-07-14T05:05:35.796000', 'stock_symbol': '453810', 'month_purchase_flag': False, 'country': 'ks', 'ratio': 0.5, 'id': 1},
-                {'updated_at': '2024-07-14T05:23:47.648000', 'stock_symbol': '368590', 'month_purchase_flag': False, 'country': 'ks', 'ratio': 0.5, 'id': 2}
-            ]
-    2. portfolio row의 month_purchase_column과 month_budget을 확인하고 아직 구매 및 할당되지 않은(False) 종목들을 가져온다.
-    3. 분기점
-    - 종목들이 있다면 distribute_asset을 실행한다.
-    - 없다면 빈 테스크를 실행한다.
-
-    """
-    # 1. db에서 Portfolio table을 가져온다.
-    response = requests.post(
-        url=f'http://{os.getenv("FASTAPI_SERVER_HOST")}:{os.getenv("FASTAPI_SERVER_PORT")}/v1/portfolio/get',
-        data=json.dumps({
-            "get_all": True,
-        })
-    )
-    portfolio_rows = response.json()
-
-    # 2. 아직 구매 및 할당되지 않는 후보 종목들의 종목 id를 구한다.
-    candidate_portfolio_rows = list(filter(
-        lambda row: row["month_purchase_flag"] is False and row["month_budget"] == 0, portfolio_rows
-    ))
-
-    if len(candidate_portfolio_rows) > 0:
-        # xcom에 저장하고 다음 task_name 반환
-        kwargs['task_instance'].xcom_push(key='candidate_portfolio_rows', value=candidate_portfolio_rows)
-        logger.info(
-            f"run distribute_asset",
-        )
-        return "distribute_asset"
-    else:
-        logger.info(
-            f"run task_empty",
-        )
-        return "task_empty"
-
-
-def distribute_asset(**kwargs):
-    """ asset 분배
-    asset을 portfolio 종목들 ratio에 따라 분배한다.
-    (단, xcom을 통해 받은 종목들은 month_budget이 아직 할당되지 않아 0이고 month_purchase_flag 또한 False인 상태이다.)
-
-    Returns:
-        status (bool): 상태
-    """
-    # 0. 앞서 구한 예수금 가져오기
-    balance = kwargs['task_instance'].xcom_pull(key='balance')
-    # 1. 앞서 구한 할당/구매 안한 포트폴리오 rows 가져오기
-    candidate_portfolio_rows = kwargs['task_instance'].xcom_pull(key='candidate_portfolio_rows')
-
-    for candidate_portfolio_row in candidate_portfolio_rows:
-        stock_symbol = candidate_portfolio_row["stock_symbol"]
-        ratio = float(candidate_portfolio_row["ratio"])
-
-        # 구매는 다음 DAG에서 수행하므로 distribute DAG에서는 month_budget만 업데이트해준다.
-        update_dict = {
-            "month_budget": balance * ratio,
-        }
-
-        response = requests.put(
-            url=f'http://{os.getenv("FASTAPI_SERVER_HOST")}:{os.getenv("FASTAPI_SERVER_PORT")}/v1/portfolio/put_fields?stock_symbol={stock_symbol}',
-            data=json.dumps(update_dict),
-        )
-        logger.info(
-            response.json(),
-        )
-
-        if response.status_code != 200:
-            raise Exception(f"status_code is {response.status_code} !")
-
-    return True

--- a/airflow/plugins/prophesy.py
+++ b/airflow/plugins/prophesy.py
@@ -6,7 +6,7 @@ import requests
 
 from const import STAY, PURCHASE, SELL
 
-dotenv.load_dotenv(f"./config/PROD.env")
+dotenv.load_dotenv(f"/home/ubuntu/zed/auto_trade/config/prod.env")
 logger = logging.getLogger("api_logger")
 
 

--- a/airflow/plugins/trade_order.py
+++ b/airflow/plugins/trade_order.py
@@ -1,0 +1,149 @@
+import json
+import os
+import logging
+import dotenv
+import requests
+
+dotenv.load_dotenv(f"/home/ubuntu/zed/auto_trade/config/prod.env")
+logger = logging.getLogger("api_logger")
+
+
+def get_portfolio_rows():
+    # 1. db에서 Portfolio table을 가져온다.
+    response = requests.post(
+        url=f'http://{os.getenv("FASTAPI_SERVER_HOST")}:{os.getenv("FASTAPI_SERVER_PORT")}/v1/portfolio/get',
+        data=json.dumps({
+            "get_all": True,
+        })
+    )
+    portfolio_rows = response.json()
+
+    return portfolio_rows
+
+def check_order_exist(next_task_name: str, **kwargs):
+    """주문 확인
+    예약 매수/매도 주문한 종목들 여부를 확인한다.
+    1. 있을 때
+    - 한투 API에 조회
+    2. 없을 때
+    - 종료
+    """
+    # db에서 Portfolio table을 가져온다.
+    portfolio_rows = get_portfolio_rows()
+
+    # 매매 신청한 종목들을 구한다.
+    candidate_portfolio_rows = list(filter(
+        lambda row: row["order_status"] in ["O", "W"], portfolio_rows
+    ))
+
+    if len(candidate_portfolio_rows) > 0:
+        kwargs['task_instance'].xcom_push(key='candidate_portfolio_rows', value=candidate_portfolio_rows)
+
+        logger.info(
+            f"run {next_task_name}",
+        )
+        return next_task_name
+    else:
+        logger.info(
+            "no order exist. run task_empty",
+        )
+        return "task_empty"
+
+def check_order(next_task_name: str, **kwargs):
+    # 전체 orders를 받아온다.
+    response = requests.post(
+        url=f'http://{os.getenv("FASTAPI_SERVER_HOST")}:{os.getenv("FASTAPI_SERVER_PORT")}/v1/trader/get_orders',
+        data=json.dumps({
+            "get_all": True,
+        })
+    )
+    rsvn_orders = response.json()["output"]
+
+    if len(rsvn_orders) > 0:
+        kwargs['task_instance'].xcom_push(key='rsvn_orders', value=rsvn_orders)
+        logger.info(
+            f"run {next_task_name}",
+        )
+        return next_task_name
+    else:
+        logger.info(
+            "run task_empty",
+        )
+        return "task_empty"
+
+
+# 주문 전송 및 slack msg 전송
+def change_status(**kwargs):
+    # 1. 앞서 구한 주문 가져오기
+    rsvn_orders = kwargs['task_instance'].xcom_pull(key='rsvn_orders')
+    # 2. 종목 포트폴리오 rows 가져오기
+    candidate_portfolio_rows = kwargs['task_instance'].xcom_pull(key='candidate_portfolio_rows')
+    pdno2budget = {
+        candidate_portfolio_row["stock_symbol"]: candidate_portfolio_row["month_budget"]
+        for candidate_portfolio_row in candidate_portfolio_rows
+    }
+
+    for rsvn_order in rsvn_orders:
+        # 종목번호
+        pdno = rsvn_order["pdno"]
+
+        order_status, update_dict = "E", {}
+        try:
+            # 종목 한글명
+            kor_item_shtn_name = rsvn_order["kor_item_shtn_name"]
+            # 매매 구분 (매도: 01, 매수: 02)
+            sll_buy_dvsn_cd = rsvn_order["sll_buy_dvsn_cd"]
+            sll_buy_dvsn_cd_str = "매도" if sll_buy_dvsn_cd == "01" else "매수"
+            # 총 체결금액
+            tot_ccld_amt = rsvn_order["tot_ccld_amt"]
+            # 처리 결과
+            prcs_rslt = rsvn_order["prcs_rslt"]
+            # 주문 구분명
+            ord_dvsn_name = rsvn_order["ord_dvsn_name"]
+
+            if prcs_rslt == "미처리":
+                order_status = "F"
+                update_dict.update({
+                    "order_status": order_status,
+                })
+            # 정상 처리된 경우
+            elif prcs_rslt == "처리":
+                order_status = "S"
+                update_dict.update({
+                    "month_purchase_flag": True,
+                    "month_budget": pdno2budget[pdno] - tot_ccld_amt, # 예산 - 체결금액
+                    "reserved_budget": 0,
+                    "order_status": order_status,
+                })
+            # 그 외 뭔가 잘못됐거나 처리 대기 케이스
+            else:
+                order_status = "W"
+                update_dict.update({
+                    "order_status": order_status,
+                })
+
+
+            logger.info(
+                f"종목 {pdno}({kor_item_shtn_name})의 {sll_buy_dvsn_cd_str} {ord_dvsn_name}는 {prcs_rslt}되었습니다. order_status: {order_status} (총액 {tot_ccld_amt})",
+            )
+
+            requests.put(
+                url=f'http://{os.getenv("FASTAPI_SERVER_HOST")}:{os.getenv("FASTAPI_SERVER_PORT")}/v1/portfolio/put_fields?stock_symbol={pdno}',
+                data=json.dumps(update_dict),
+            )
+
+        except Exception as e:
+            logger.info(
+                f"종목 {pdno}을 처리하던 중 에러 발생 {e}",
+            )
+            order_status = "E"
+        finally:
+            input_text = f"종목 {pdno}는 현재 {order_status} 상태입니다."
+            channel_id = os.getenv("TRADE_ALARM_CHANNEL")
+            requests.post(
+                url=f'http://{os.getenv("FASTAPI_SERVER_HOST")}:{os.getenv("FASTAPI_SERVER_PORT")}/v1/slackbot/send_message',
+                data=json.dumps({
+                    "channel_id": channel_id,
+                    "input_text": input_text,
+                }),
+            )

--- a/fastapi_server/controllers/slackbot_controller.py
+++ b/fastapi_server/controllers/slackbot_controller.py
@@ -1,0 +1,30 @@
+import logging
+import inject
+
+from fastapi import APIRouter, Request
+from fastapi_server.slack import KISSlackBot
+
+
+router = APIRouter(
+    prefix="/v1/slackbot",
+    tags=["Slackbot"],
+)
+
+slack_bot = inject.instance(KISSlackBot)
+
+
+logger = logging.getLogger("api_logger")
+
+
+@router.post("/send_message")
+async def prophet(request: Request, input_text: str, channel_id: str):
+    slack_bot.post_message(
+        channel_id=channel_id,
+        text=input_text,
+    )
+    logger.inform(
+        input_text,
+        extra={"endpoint_name": request.url.path}
+    )
+
+    return True

--- a/fastapi_server/controllers/trader_controller.py
+++ b/fastapi_server/controllers/trader_controller.py
@@ -149,3 +149,18 @@ async def sell(request: Request):
     )
 
     return res
+
+
+@router.post("/get_orders")
+async def get_orders(request: Request, rsvn_ord_start_dt: str, rsvn_ord_end_dt: str):
+    res = trader.get_reserved_orders(
+        rsvn_ord_start_dt=rsvn_ord_start_dt,
+        rsvn_ord_end_dt=rsvn_ord_end_dt,
+    )
+
+    logger.inform(
+        f"get orders from {rsvn_ord_start_dt} - {rsvn_ord_end_dt} | Status {res['status_code']} | Error {res['error']}",
+        extra={"endpoint_name": request.url.path}
+    )
+
+    return res

--- a/fastapi_server/entity/portfolio.py
+++ b/fastapi_server/entity/portfolio.py
@@ -13,6 +13,8 @@ class PortfolioBase(SQLModel):
     country: str = Field(default='ks', nullable=False)
     month_purchase_flag: bool = Field(default=False, nullable=False)
     month_budget: int = Field(default=0, nullable=False)
+    reserved_budget: int = Field(default=0, nullable=False)
+    order_status: str = Field(default="N", nullable=False)
     updated_at: datetime = Field(default_factory=get_default_updated_at, nullable=False)
 
 

--- a/fastapi_server/main.py
+++ b/fastapi_server/main.py
@@ -5,7 +5,7 @@ from fastapi_server.utils import FastAPIServer, get_controllers
 from fastapi_server.utils import initialize_api_logger
 
 
-dotenv.load_dotenv(f"./config/prod.env")
+dotenv.load_dotenv(f"/home/ubuntu/zed/auto_trade/config/prod.env")
 initialize_api_logger()
 Initializer()
 

--- a/prophecy.py
+++ b/prophecy.py
@@ -119,7 +119,7 @@ class ProphetModel:
 
 if __name__ == "__main__":
     import dotenv
-    dotenv.load_dotenv(f"./config/prod.env")
+    dotenv.load_dotenv(f"/home/ubuntu/zed/auto_trade/config/prod.env")
     pf = ProphetModel()
 
     stock_rows = [{'country': 'ks', 'accum_asset': 5000.0, 'stock_symbol': '453810', 'id': 1, 'ratio': 0.3}]

--- a/trader.py
+++ b/trader.py
@@ -326,6 +326,53 @@ class Trader:
 
         return self._request(api, data, headers, method="GET")
 
+    def get_reserved_orders(self, rsvn_ord_start_dt: str, rsvn_ord_end_dt: str):
+        """
+        국내 예약 주문 조회
+        예약 주문 내역을 전체를 확인할 수 있다.
+
+        Returns:
+            status_code (str): 상태 코드, (200 | 4xx | 5xx)
+            output (dict): 주문 결과 KRX_FWDG_ORD_ORGNO(한국거래소 전송주문조직번호), ORNO(주문번호), ORD_TMD(주문시간)을 갖는다.
+            error (str): 에러
+
+        """
+        tr_id = os.getenv("RSVN_ORD_TR_ID")
+        api = "uapi/domestic-stock/v1/trading/order-resv-ccnl"
+
+        data = {
+            # 예약주문일자
+            "RSVN_ORD_ORD_DT": rsvn_ord_start_dt,
+            "RSVN_ORD_END_DT": rsvn_ord_end_dt,
+            "RSVN_ORD_SEQ": "",
+            # 단말매체종류카드
+            "TMNL_MDIA_KIND_CD":"00",
+            # 계좌번호
+            "CANO": os.getenv("ACCOUNT_FRONT"),
+            "ACNT_PRDT_CD": os.getenv("ACCOUNT_REAR"),
+
+            "PRCS_DVSN_CD": "0",
+            "CNCL_YN": "Y",
+            # 종목코드 (공백 시 전체)
+            "PDNO": "",
+            "SLL_BUY_DVSN_CD": "",
+            "CTX_AREA_FK200": "",
+            "CTX_AREA_NK200": ""
+        }
+
+        headers = {
+            "Content-Type": "application/json",
+            "authorization": f"Bearer {self.access_token}",
+            "appKey": self.app_key,
+            "appSecret": self.app_secret,
+            "tr_id": tr_id,
+            # 개인
+            "custtype": "P",
+            "hashkey": self.hashkey(data)
+        }
+
+        return self._request(api, data, headers, method="GET")
+
     # inquire_balance는 API response지만 get_balance는 직접 남은 예수금을 가져온다.
     def get_balance(self):
         response_json = self.inquire_balance()


### PR DESCRIPTION
## Title
- purchase & check

## Description
- 구매가 예약주문으로 이루어지므로 해당 주문의 체결 여부를 확인하는 신규 DAG 추가(check_order_dag)
  - 한투 API의 예약 주문 조회 API 사용
- portfolio entity에 reserved_budget과 order_status 신규 field 추가
  - reserved_budget: 예약금. 예수금에서 해당 주식 구매에 걸어놓은 금액
  - order_status: 예약 매매 주문의 상태. 이 값에 따라 주문 조회 및 예약 주문을 수행
    - W: 대기상태
    - O: 예약 매매 걸어놓은 상태
    - F: 실패
    - S: 성공(처리됨)

## Linked Issues
- resolved #51
