### PR TITLE
[#54] 구매 전략 강화 (통계 지표 활용, RSI, MA, ZScore)

### DIFF
--- a/airflow/plugins/common/statistics.py
+++ b/airflow/plugins/common/statistics.py
@@ -1,0 +1,23 @@
+def get_rsi(target_df, n_days: int):
+    close_diff = target_df.tail(n_days)['Close'].diff()
+    avg_gains = close_diff[close_diff > 0].mean()
+    avg_loss = -close_diff[close_diff < 0].mean()
+
+    # 상대강도
+    rs = avg_gains / avg_loss
+    # RSI
+    rsi = 100 - (100 / (1 + rs))
+
+    return float(round(rsi, 2))
+
+def get_moving_averages(target_df):
+    day5_close_avg, day10_close_avg, day20_close_avg, day60_close_avg = target_df["Close"][-5:].mean(), target_df["Close"][-10:].mean(), target_df["Close"][-20:].mean(), target_df["Close"][-60:].mean()
+
+    return float(round(day5_close_avg)), float(round(day10_close_avg)), float(round(day20_close_avg)), float(round(day60_close_avg))
+
+def get_zscore(target_df, n_days: int):
+    target_close_series = target_df.tail(n_days)["Close"]
+    today_close, close_mean, close_std = target_close_series[-1], target_close_series.mean(), target_close_series.std()
+
+    zscore = (today_close - close_mean) / close_std
+    return float(round(zscore))

--- a/airflow/plugins/prophesy.py
+++ b/airflow/plugins/prophesy.py
@@ -1,10 +1,14 @@
+
 import json
 import os
 import logging
 import dotenv
 import requests
+from datetime import datetime, timedelta
+import yfinance as yf
 
 from const import STAY, PURCHASE, SELL
+from common.statistics import get_rsi, get_moving_averages, get_zscore
 
 dotenv.load_dotenv(f"/home/ubuntu/zed/auto_trade/config/prod.env")
 logger = logging.getLogger("api_logger")
@@ -52,10 +56,12 @@ def prophesy_portfolio(**kwargs):
 
     # 2. 매매 threshold를 만족하는 경우를 모아 반환한다.
     for stock_symbol, prophecy in stock_symbol2prophecy.items():
+        stock_symbol_tz = stock_symbol
         stock_symbol = stock_symbol.split(".")[0]
         last_price, diff_rate = prophecy["last_price"], prophecy["diff_rate"]
-        behavior = _get_behavior(
+        behavior, behavior_reason = _get_behavior(
             diff_rate=diff_rate,
+            statistics=_get_statistics(stock_symbol=stock_symbol_tz),
             order_status=stock_symbol2order_status[stock_symbol],
             purchase_threshold=float(os.getenv("PURCHASE_THRESHOLD")),
             sell_threshold=float(os.getenv("SELL_THRESHOLD")),
@@ -65,10 +71,51 @@ def prophesy_portfolio(**kwargs):
             (stock_symbol, behavior, diff_rate, stock_symbol2month_budget[stock_symbol], last_price)
         )
 
+        input_text = f"{stock_symbol}: {behavior} - {behavior_reason}"
+        channel_id = os.getenv("DAILY_REPORT_CHANNEL")
+        print(f"channel_id: {channel_id}")
+        response = requests.post(
+            url=f'http://{os.getenv("FASTAPI_SERVER_HOST")}:{os.getenv("FASTAPI_SERVER_PORT")}/v1/slackbot/send_message',
+            data=json.dumps({
+                "channel_id": channel_id,
+                "input_text": input_text,
+            }),
+        )
+
     kwargs['task_instance'].xcom_push(key='portfolio_behavior_decisions', value=portfolio_behavior_decisions)
     logger.info(f"portfolio_behavior_decisions: {portfolio_behavior_decisions}")
 
     return True
+
+def _get_statistics(stock_symbol: str, n_days: int = 20):
+    """주식 종목의 통계치를 가져온다.
+    RSI, MA, ZSCORE를 반환한다.
+
+    Args:
+        stock_symbol (str): 주식 종목 심볼 (ex. 005930.KS)
+        n_days (str): 통계 계산할 과거 영업일 수
+
+    Returns:
+        statistics (dict): 종목의 통계치
+
+    """
+    end = datetime.now() + timedelta(days=1)
+    price_df = yf.download(stock_symbol)
+
+
+    day5_close_avg, day10_close_avg, day20_close_avg, day60_close_avg = get_moving_averages(price_df)
+    statistics = {
+        "rsi": get_rsi(target_df=price_df, n_days=n_days),
+        "ma": {
+            "day5": day5_close_avg,
+            "day10": day10_close_avg,
+            "day20": day20_close_avg,
+            "day60": day60_close_avg,
+        },
+        "zscore": get_zscore(target_df=price_df, n_days=n_days),
+    }
+
+    return statistics
 
 
 def execute_decisions(**kwargs):
@@ -81,7 +128,7 @@ def execute_decisions(**kwargs):
     logger.info(f"portfolio_behavior_decisions: {portfolio_behavior_decisions}")
     # 2. 결정 수행
     for portfolio_behavior_decision in portfolio_behavior_decisions:
-        stock_symbol, behavior, diff_rate, month_budget, last_price = portfolio_behavior_decision
+        stock_symbol, behavior, _, month_budget, last_price = portfolio_behavior_decision
         ord_qty = int(month_budget // last_price)
         last_price = int(last_price)
         result = None
@@ -131,6 +178,7 @@ def execute_decisions(**kwargs):
 
 def _get_behavior(
     diff_rate: float,
+    statistics: dict,
     order_status: str,
     purchase_threshold: float,
     sell_threshold: float,
@@ -139,19 +187,55 @@ def _get_behavior(
 
     Args:
         diff_rate (float): 종목의 기울기를 의미한다. 동작 판별의 근거가 된다.
+        statistics (dict): 종목의 통계치
         order_status (str): 매매 주문 상태
         purchase_threshold (float): 매수 기준점
         sell_threshold (float): 매도 기준점
 
     Returns:
         behavior (str): const에 정의된 행동 (PURCHASE | SELL | STAY) 중 하나이다.
+        behavior_reason (str): 행동 결정의 근거를 설명한다.
 
     """
-    behavior = STAY
+    behavior, behavior_reason = STAY, ""
     # 종목 상태가 예약 매수가 진행된 적이 없거나 실패한 상태일 때 수행한다.
-    if diff_rate >= purchase_threshold and order_status in ["N", "F"]:
-        behavior = PURCHASE
-    elif diff_rate <= sell_threshold and order_status in ["N", "F"]:
-        behavior = SELL
+    statisstics_behavior, model_behavior = STAY, STAY
+    # 1. rsi, ma, zscore로 행동을 결정한다.
+    if (
+        statistics["rsi"] >= 70
+        and statistics["ma"]["day5"] > statistics["ma"]["day20"]
+        and statistics["zscore"] >= 1
+    ):
+        statisstics_behavior = SELL
+        behavior_reason += f"statistics {statistics} is overbought | "
+    elif (
+        statistics["rsi"] <= 30
+        and statistics["ma"]["day5"] < statistics["ma"]["day20"]
+        and statistics["zscore"] <= -1
+    ):
+        statisstics_behavior = PURCHASE
+        behavior_reason += f"statistics {statistics} is oversold | "
+    else:
+        behavior_reason += f"statistics {statistics} is normal | "
 
-    return behavior
+    # 2. meta prophet 모델의 예측값을 통해 행동을 결정한다.
+    if diff_rate >= purchase_threshold:
+        model_behavior = PURCHASE
+        behavior_reason += f"diff_rate {diff_rate} is over purchase_threshold {purchase_threshold}"
+    elif diff_rate <= sell_threshold:
+        model_behavior = SELL
+        behavior_reason += f"diff_rate {diff_rate} is under sell_threshold {sell_threshold}"
+    else:
+        model_behavior = STAY
+
+    # 3. 최종 행동을 결정한다
+    if order_status not in ["N", "F"]:
+        behavior = STAY
+    elif statisstics_behavior == PURCHASE or model_behavior == PURCHASE:
+        behavior = PURCHASE
+    elif statisstics_behavior == SELL and model_behavior == SELL:
+        behavior = SELL
+    else:
+        behavior = STAY
+
+    return behavior, behavior_reason

--- a/airflow/plugins/prophesy.py
+++ b/airflow/plugins/prophesy.py
@@ -207,24 +207,25 @@ def _get_behavior(
         and statistics["zscore"] >= 1
     ):
         statisstics_behavior = SELL
-        behavior_reason += f"statistics {statistics} is overbought | "
+        behavior_reason += f"statistics {statistics} is overbought. it's time to sell"
+    # 구매에는 보다 유연한 기준을 적용한다.
     elif (
-        statistics["rsi"] <= 30
-        and statistics["ma"]["day5"] < statistics["ma"]["day20"]
-        and statistics["zscore"] <= -1
+        int(statistics["rsi"]) <= 40
+        or statistics["ma"]["day5"] < statistics["ma"]["day20"]
+        or statistics["zscore"] <= -1
     ):
         statisstics_behavior = PURCHASE
-        behavior_reason += f"statistics {statistics} is oversold | "
+        behavior_reason += f"statistics {statistics} is oversold. it's time to buy"
     else:
-        behavior_reason += f"statistics {statistics} is normal | "
+        behavior_reason += f"statistics {statistics} is normal"
 
     # 2. meta prophet 모델의 예측값을 통해 행동을 결정한다.
     if diff_rate >= purchase_threshold:
         model_behavior = PURCHASE
-        behavior_reason += f"diff_rate {diff_rate} is over purchase_threshold {purchase_threshold}"
+        behavior_reason += f" | diff_rate {diff_rate} is over purchase_threshold {purchase_threshold}"
     elif diff_rate <= sell_threshold:
         model_behavior = SELL
-        behavior_reason += f"diff_rate {diff_rate} is under sell_threshold {sell_threshold}"
+        behavior_reason += f" | diff_rate {diff_rate} is under sell_threshold {sell_threshold}"
     else:
         model_behavior = STAY
 

--- a/fastapi_server/controllers/slackbot_controller.py
+++ b/fastapi_server/controllers/slackbot_controller.py
@@ -3,6 +3,7 @@ import inject
 
 from fastapi import APIRouter, Request
 from fastapi_server.slack import KISSlackBot
+from fastapi_server.entity.slack_base import SlackBase
 
 
 router = APIRouter(
@@ -17,13 +18,13 @@ logger = logging.getLogger("api_logger")
 
 
 @router.post("/send_message")
-async def prophet(request: Request, input_text: str, channel_id: str):
+async def prophet(request: Request, slack_base: SlackBase):
     slack_bot.post_message(
-        channel_id=channel_id,
-        text=input_text,
+        channel_id=slack_base.channel_id,
+        text=slack_base.input_text,
     )
     logger.inform(
-        input_text,
+        slack_base.input_text,
         extra={"endpoint_name": request.url.path}
     )
 

--- a/fastapi_server/entity/slack_base.py
+++ b/fastapi_server/entity/slack_base.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class SlackBase(BaseModel):
+    input_text: str
+    channel_id: str


### PR DESCRIPTION
## Title
- purchase logic

## Description
- 기존 전략은 다음 달에 4~5% 이상의 종가 증가가 예상될 경우에 구매하는 것이었다. 하지만 빈약한 제한적인 조건으로 구매가 좀처럼 이뤄지지 않아 월 1회 적립식 구매 전략에 맞지 않는다. 따라서 통계적 지표를 활용하여 구매 케이스를 늘리기 위함
- 통계 지표
  - RSI (Relative Strength Index)
    - 주가의 상대적 강도로 과매수/과매도 상태를 파악해 과매도 구간에서는 매수 시그널을, 과매수 수간에서는 매도 시그널로 사용한다.
  - MA (Moving Average)
    - 일반적인 이동평균선으로 20일치(영업일 기준 한달)과 5일(일주일)을 활용한다. 한달MA보다 일주일 MA가 높다면 지금이 상승 추세인 것
  - Z-Score
    - 오늘 종가가 평균에서 얼마나 떨어져 있는지 확인
    - Z-Score <= -1 이라는 것은 평균보다 1표준편차 아래로 떨어진 것을 뜻한다.
-> 통계 지표는 매수에서는 or로 묶고 매도에는 and로 묶었다. 

## Linked Issues
- resolved #54 
