### PR TITLE
[#61] 예수금 분배 로직 수정 (일괄 분배)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Auto Trade는 포트폴리오를 구성한 뒤, 이들 종목에 대해 매월 �
 
 저는 주식 투자를 하고 싶었지만 매일 차트를 보며 매수/매도 시점을 잡느라 에너지를 쓰고 싶지 않았습니다.
 
-또한 제게는 시장의 흐름을 읽을 정도의 경제적 지식도 없습니다. 
+또한 제게는 시장의 흐름을 읽을 정도의 경제적 지식도 없습니다.
 
 적립식 장기투자이니 매수는 항상 발생합니다. 다만 언제 사느냐가 중요하겠지요.
 
@@ -64,10 +64,10 @@ fastapi 서버와 각 airflow scheduler와 webserver는 각각의 tmux 세션에
 
 ### prerequisite
 - 환경
-    - 본 프로젝트는 EC2 free tier 장비에서 수행되었습니다. 
+    - 본 프로젝트는 EC2 free tier 장비에서 수행되었습니다.
 	    - t2.micro (1 vCPU / 1GB RAM / 25 GB storage)
 	- swap memory를 사용하지 않으면 airflow를 작동시키는 데 어려움이 있을 수 있습니다.
-    
+
 
     ```
     # check swap memory

--- a/airflow/plugins/asset_update.py
+++ b/airflow/plugins/asset_update.py
@@ -77,19 +77,13 @@ def check_portfolio(**kwargs):
                 {'updated_at': '2024-07-14T05:05:35.796000', 'stock_symbol': '453810', 'month_purchase_flag': False, 'country': 'ks', 'ratio': 0.5, 'id': 1},
                 {'updated_at': '2024-07-14T05:23:47.648000', 'stock_symbol': '368590', 'month_purchase_flag': False, 'country': 'ks', 'ratio': 0.5, 'id': 2}
             ]
-    2. portfolio row의 month_purchase_column과 month_budget을 확인하고 아직 구매 및 할당되지 않은(False) 종목들을 가져온다.
-    3. 분기점
+    2. 분기점
     - 종목들이 있다면 distribute_asset을 실행한다.
     - 없다면 빈 테스크를 실행한다.
 
     """
     # 1. db에서 Portfolio table을 가져온다.
-    portfolio_rows = get_portfolio_rows()
-
-    # 2. 아직 예산이 할당되지 않았고 매수 신청을 하지 않은 후보 종목들의 종목 id를 구한다.
-    candidate_portfolio_rows = list(filter(
-        lambda row: row["order_status"] == "N" and row["month_budget"] == 0, portfolio_rows
-    ))
+    candidate_portfolio_rows = get_portfolio_rows()
 
     if len(candidate_portfolio_rows) > 0:
         # xcom에 저장하고 다음 task_name 반환
@@ -107,15 +101,14 @@ def check_portfolio(**kwargs):
 
 def distribute_asset(**kwargs):
     """ asset 분배
-    asset을 portfolio 종목들 ratio에 따라 분배한다.
-    (단, xcom을 통해 받은 종목들은 month_budget이 아직 할당되지 않아 0이고 month_purchase_flag 또한 False인 상태이다.)
+    asset을 portfolio 종목들에 ratio에 따라 분배한다.
 
     Returns:
         status (bool): 상태
     """
     # 0. 앞서 구한 예수금 가져오기
     balance = kwargs['task_instance'].xcom_pull(key='balance')
-    # 1. 앞서 구한 할당/구매 안한 포트폴리오 rows 가져오기
+    # 1. 앞서 구한 포트폴리오 rows 가져오기
     candidate_portfolio_rows = kwargs['task_instance'].xcom_pull(key='candidate_portfolio_rows')
 
     input_text = ""
@@ -123,9 +116,11 @@ def distribute_asset(**kwargs):
         stock_symbol = candidate_portfolio_row["stock_symbol"]
         ratio = float(candidate_portfolio_row["ratio"])
 
-        # 구매는 다음 DAG에서 수행하므로 distribute DAG에서는 month_budget만 업데이트해준다.
+        # distribute DAG에서는 매월 예수금 이체되면 분배한다. 구매 상태와 상관없이 month_budget와 상태를 초기화해준다.
         update_dict = {
             "month_budget": balance * ratio,
+            "month_purchase_flag": False,
+            "order_status": "N",
         }
 
         response = requests.put(


### PR DESCRIPTION
## Title
- rm portfolio filtering logic. now we could update all in once

## Description
- 기존에는 매일 현재 예수금을 확인하고 분배했지만 지금은 월에 하루만 확인하고 분배한다.
- 따라서 예수금이 이체됐다는 가정을 전제하므로 모든 포트폴리오 종목들에 대해 예수금을 분배하면 된다.
- 구매한 종목들에 대해 purchase_flag가 update되지 않는 문제 해결

## Linked Issues
- resolved #61 
