### PR TITLE
[#48] deprecated 예정인 file_upload method 변경

### DIFF
--- a/fastapi_server/controllers/trader_controller.py
+++ b/fastapi_server/controllers/trader_controller.py
@@ -83,7 +83,8 @@ async def prophet(request: Request, prophet: Prophet):
         _ = slack_bot.post_file(
             channel_id=channel_id,
             thread_ts=thread_ts,
-            save_path=fig_save_path,
+            file_path=fig_save_path,
+            filename=f"prop_{stock_symbol}",
         )
 
     logger.inform(f"prophecies {prophecies}", extra={"endpoint_name": request.url.path})
@@ -106,7 +107,8 @@ async def monthly_report(request: Request, report: Report):
     _ = slack_bot.post_file(
         channel_id=channel_id,
         thread_ts=thread_ts,
-        save_path=fig_save_path,
+        file_path=fig_save_path,
+        filename="monthly_report",
     )
 
     logger.inform(f"text {text} sended with {fig_save_path}", extra={"endpoint_name": request.url.path})

--- a/fastapi_server/controllers/trader_controller.py
+++ b/fastapi_server/controllers/trader_controller.py
@@ -84,7 +84,7 @@ async def prophet(request: Request, prophet: Prophet):
             channel_id=channel_id,
             thread_ts=thread_ts,
             file_path=fig_save_path,
-            filename=f"prop_{stock_symbol}",
+            filename=f"prop_{stock_symbol}.jpg",
         )
 
     logger.inform(f"prophecies {prophecies}", extra={"endpoint_name": request.url.path})

--- a/fastapi_server/slack.py
+++ b/fastapi_server/slack.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Union
+import requests
+from io import BytesIO
 
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
@@ -32,7 +33,8 @@ class KISSlackBot:
         except SlackApiError as e:
             logger.error(f"Error posting message: {e}")
 
-    def post_file(
+    # 3.11 자로 slack side deprecated
+    def deprecated_post_file(
         self,
         save_path: str,
         thread_ts: str = None,
@@ -52,11 +54,65 @@ class KISSlackBot:
         except SlackApiError as e:
             logger.error(f"Error posting message: {e}")
 
+    def post_file(
+        self,
+        file_path: str,
+        filename: str,
+        channel_id: str,
+        thread_ts: str = None,
+    ):
+        # ID of the channel you want to send the message to
+        file_stream = BytesIO()
+        with open(file_path, "rb") as f:
+            file_stream.write(f.read())
+
+        file_stream.seek(0, 2)  # 파일 끝으로 이동하여 크기 확인
+        length = file_stream.tell()
+        file_stream.seek(0)  # 다시 처음으로 이동
+
+        try:
+            # 1. 파일 업로드할 url 받기
+            result = self.client.files_getUploadURLExternal(
+                filename=filename,
+                length=length,
+            )
+            logger.info(result)
+
+            upload_url_data = result
+            upload_url = upload_url_data["upload_url"]
+            file_id = upload_url_data["file_id"]
+            # 2. 업로드 URL로 이미지 업로드
+            requests.post(
+                upload_url,
+                files={'file': (filename, file_stream, "image/jpeg")}  # MIME 타입 설정 (JPG/PNG 등)
+            )
+
+            # 3. 업로드 완료 요청
+            self.client.files_completeUploadExternal(
+                files=[
+                    {"id": file_id, "title": filename}
+                ],
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+            )
+
+            return result
+
+        except SlackApiError as e:
+            logger.error(f"Error posting message: {e}")
+
 
 if __name__ == "__main__":
     slackbot = KISSlackBot(slack_bot_token="xoxb-...")
-    slackbot.post_message(
-        channel_id="test",
-        # thread_ts="1722946045.578359",
-        text="on test",
+    # slackbot.post_message(
+    #     channel_id="test",
+    #     # thread_ts="1722946045.578359",
+    #     text="on test",
+    # )
+
+    slackbot.post_file(
+        file_path = "/Users/limdohoon/PycharmProjects/auto-trade/test.png",
+        filename="test_file",
+        channel_id="C08FRRB60Q6",
+        # thread_ts=
     )


### PR DESCRIPTION
## Title
- file upload deprecated

## Description
- 3.11부터 사용하지 못하는 기능이므로 대안으로 수정
  - 기존에는 파일 경로를 주고 하나의 함수 files_upload_v2로 할 수 있었음
  - 변경안으로는 3가지 과정을 거쳐야함
    - verified upload url을 받아오는 request 전송
    - 파일을 byteIO로 stream해 upload url에 보내는 request 전송
    - file upload를 complete하는 request 전송

## Linked Issues
- resolved #48 
