### PR TITLE
[#83] docker compose에서의 airflow volume mount와 image의 inner copy 충돌 해결

### DIFF
--- a/airflow/dockerfile
+++ b/airflow/dockerfile
@@ -9,3 +9,4 @@ RUN pip3 install apache-airflow==${AIRFLOW_VERSION} -r requirements.txt
 COPY ./dags /opt/airflow/dags
 COPY ./plugins /opt/airflow/plugins
 COPY ./airflow.cfg /opt/airflow/airflow.cfg
+COPY ./airflow.db /opt/airflow/airflow.db

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,7 +85,7 @@ x-airflow-common:
     AIRFLOW_PROJ_DIR: ./airflow
 
   volumes:
-    - ${AIRFLOW_PROJ_DIR:-./airflow}/:/opt/airflow
+    - ${AIRFLOW_PROJ_DIR:-./airflow}/logs:/opt/airflow/logs
     - ${AIRFLOW_PROJ_DIR:-./shared}/:/shared
   user: "0:0"
 


### PR DESCRIPTION
## Title
- fix with not mounting all directory but only the logs

## Description
- docker volume mount가 무엇보다 우선해서 도커 이미지 변경사항을 씹어버림
- 마운트 구간을 /airflow -> /airflow/logs 로 필요한 일부만 마운트하게 변경하고 도커 이미지 내부를 사용하게 변경

## Linked Issues
- resolved #83 
