### PR TITLE
[#82] 슬랙 메시지 포멧과 형식 업그레이드 (message -> attachment)

### DIFF
--- a/airflow/plugins/prophesy.py
+++ b/airflow/plugins/prophesy.py
@@ -66,12 +66,22 @@ def prophesy_portfolio(**kwargs):
             (stock_symbol, behavior, diff_rate, stock_symbol2month_budget[stock_symbol], last_price)
         )
 
-        input_text = f"{stock_symbol}: {behavior} - {behavior_reason}"
         channel_id = os.getenv("DAILY_REPORT_CHANNEL")
         print(f"channel_id: {channel_id}")
+
+        color = "#ea602e" if behavior == PURCHASE else "#0b36f3" if behavior == SELL else "#F69709"
+
         response = requests.post(
-            url=f'http://{os.getenv("FASTAPI_SERVER_HOST")}:{os.getenv("FASTAPI_SERVER_PORT")}/v1/slackbot/send_message',
-            data=json.dumps({"channel_id": channel_id, "input_text": input_text}),
+            url=f'http://{os.getenv("FASTAPI_SERVER_HOST")}:{os.getenv("FASTAPI_SERVER_PORT")}/v1/slackbot/send_attachment',
+            data=json.dumps(
+                {
+                    "channel_id": channel_id,
+                    "color": color,
+                    "title": f"{stock_symbol} Statistics",
+                    "text": f"decision: {behavior}",
+                    "field_dict": statistics,
+                }
+            ),
         )
 
     kwargs["task_instance"].xcom_push(key="portfolio_behavior_decisions", value=portfolio_behavior_decisions)

--- a/fastapi_server/controllers/slackbot_controller.py
+++ b/fastapi_server/controllers/slackbot_controller.py
@@ -1,7 +1,7 @@
 import logging
 
 import inject
-from entity.slack_base import SlackBase
+from entity.slack_base import SlackAttachment, SlackBase
 from fastapi import APIRouter, Request
 from slack import KISSlackBot
 
@@ -14,8 +14,23 @@ logger = logging.getLogger("api_logger")
 
 
 @router.post("/send_message")
-async def prophet(request: Request, slack_base: SlackBase):
+async def send_message(request: Request, slack_base: SlackBase):
     slack_bot.post_message(channel_id=slack_base.channel_id, text=slack_base.input_text)
     logger.inform(slack_base.input_text, extra={"endpoint_name": request.url.path})
+
+    return True
+
+
+@router.post("/send_attachment")
+async def send_attachment(request: Request, slack_attachment: SlackAttachment):
+    slack_bot.post_attachment(
+        channel_id=slack_attachment.channel_id,
+        color=slack_attachment.color,
+        pretext=slack_attachment.pretext,
+        title=slack_attachment.title,
+        text=slack_attachment.text,
+        statistics=slack_attachment.field_dict,
+    )
+    logger.inform(slack_attachment.field_dict, extra={"endpoint_name": request.url.path})
 
     return True

--- a/fastapi_server/controllers/trader_controller.py
+++ b/fastapi_server/controllers/trader_controller.py
@@ -66,8 +66,15 @@ async def prophet(request: Request, prophet: Prophet):
     channel_id = os.getenv("DAILY_REPORT_CHANNEL")
     for stock_symbol, prophecy_dict in prophecies.items():
         fig_save_path = prophecy_dict.pop("fig_save_path", None)
-        text = f"{stock_symbol} - [변화율]: {prophecy_dict['diff_rate']} / [금일 종가]: {prophecy_dict['last_price']}"
-        response = slack_bot.post_message(channel_id=channel_id, text=text)
+
+        diff_rate = prophecy_dict["diff_rate"]
+        color = "#ea602e" if diff_rate >= 0 else "#0660f2"
+        last_price = prophecy_dict["last_price"]
+        statistics = {"변화율": diff_rate, "금일 종가": last_price}
+
+        response = slack_bot.post_attachment(
+            channel_id=channel_id, color=color, title=stock_symbol, statistics=statistics
+        )
 
         thread_ts = response["ts"]
         channel_id = response["channel"]

--- a/fastapi_server/entity/slack_base.py
+++ b/fastapi_server/entity/slack_base.py
@@ -4,3 +4,22 @@ from pydantic import BaseModel
 class SlackBase(BaseModel):
     input_text: str
     channel_id: str
+
+
+class SlackAttachment(BaseModel):
+    channel_id: str
+    color: str
+    pretext: str = None
+    title: str = None
+    text: str = None
+    field_dict: dict = {}
+
+    def to_dict(self):
+        return {
+            "channel_id": self.channel_id,
+            "color": self.color,
+            "pretext": self.pretext,
+            "title": self.title,
+            "text": self.text,
+            "field_dict": self.field_dict,
+        }

--- a/fastapi_server/slack.py
+++ b/fastapi_server/slack.py
@@ -124,6 +124,11 @@ if __name__ == "__main__":
         "ma": {"day5": 13695.0, "day10": 13768.0, "day20": 13808.0, "day60": 13726.0},
         "zscore": -3.0,
     }
+
+    # statistics = {
+    #     "변화율": -2.59,
+    #     "금일 종가":23695,
+    # }
     slackbot.post_attachment(
         channel_id="C08FRRB60Q6",
         color="#2eb886",
@@ -132,6 +137,14 @@ if __name__ == "__main__":
         text="decision: HOLD",
         statistics=statistics,
     )
+    # slackbot.post_attachment(
+    #     channel_id="C08FRRB60Q6",
+    #     color="#ea602e",
+    #     thread_ts="1722946045.578359",
+    #     title="453810.KS",
+    #     # text="decision: HOLD",
+    #     statistics=statistics,
+    # )
     # slackbot.post_file(
     #     file_path="/Users/limdohoon/PycharmProjects/auto-trade/test.png",
     #     filename="test_file",


### PR DESCRIPTION
## Title
- slack format attachment 

## Description
- 형식: 메시지 -> 틀이 있는 구성
- 포멧
  - 상승과 하락 그리고 매수와 매도 여부에 따라 색으로 표현되게 하여 보다 직관적으로 판단 가능하게 함
- 예시1
  - <img width="331" height="401" alt="image" src="https://github.com/user-attachments/assets/60d8ab3a-0bd3-4da0-bd71-a9e07246c187" />
- 예시2
  - <img width="615" height="469" alt="image" src="https://github.com/user-attachments/assets/cdff79ac-7f3d-4bda-9c86-76954801e651" />



## Linked Issues
- resolved #82 