### PR TITLE
[#92] 한투 매매 관련 API 추가 및 수정

### DIFF
--- a/airflow/airflow.cfg
+++ b/airflow/airflow.cfg
@@ -136,7 +136,7 @@ donot_pickle = True
 #
 # Variable: AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT
 #
-dagbag_import_timeout = 30.0
+dagbag_import_timeout = 60.0
 
 # Should a traceback be shown in the UI for dagbag import errors,
 # instead of just the exception message
@@ -155,7 +155,7 @@ dagbag_import_error_traceback_depth = 2
 #
 # Variable: AIRFLOW__CORE__DAG_FILE_PROCESSOR_TIMEOUT
 #
-dag_file_processor_timeout = 50
+dag_file_processor_timeout = 100
 
 # The class to use for running task instances in a subprocess.
 # Choices include StandardTaskRunner, CgroupTaskRunner or the full import path to the class
@@ -1231,13 +1231,13 @@ session_backend = database
 #
 # Variable: AIRFLOW__WEBSERVER__WEB_SERVER_MASTER_TIMEOUT
 #
-web_server_master_timeout = 120
+web_server_master_timeout = 240
 
 # Number of seconds the gunicorn webserver waits before timing out on a worker
 #
 # Variable: AIRFLOW__WEBSERVER__WEB_SERVER_WORKER_TIMEOUT
 #
-web_server_worker_timeout = 300
+web_server_worker_timeout = 480
 
 # Number of workers to refresh at a time. When set to 0, worker refresh is
 # disabled. When nonzero, airflow periodically refreshes webserver workers by

--- a/fastapi_server/controllers/trader_controller.py
+++ b/fastapi_server/controllers/trader_controller.py
@@ -158,7 +158,9 @@ async def rsvn_buy(request: Request, rsvn_buy: RsvnBuy):
 
 
 @router.post("/cancel_fix")
-async def cancel(request: Request, ord_orgno: int, orgn_odno: int, method_code: str = "02", fix_price: str = 0):
+async def cancel(
+    request: Request, ord_orgno: int, orgn_odno: int, method_code: str = "02", fix_price: str = "0"
+):
     res = trader.cancel_request(
         ord_orgno=str(ord_orgno), orgn_odno=str(orgn_odno), method_code=method_code, fix_price=fix_price
     )

--- a/fastapi_server/controllers/trader_controller.py
+++ b/fastapi_server/controllers/trader_controller.py
@@ -119,7 +119,7 @@ async def buy(request: Request, buy: Buy):
         stock_code=buy.stock_symbol,
         ord_qty=buy.ord_qty,
         ord_price=buy.ord_price,
-        rsvn_ord_end_dt=buy.rsvn_ord_end_dt,
+        # rsvn_ord_end_dt=buy.rsvn_ord_end_dt,
         # 장전 시간외는 전날 종가를 사용하지만 공란으로 비우지말고 0을 넣으라고 하는데 그럼 안되고 일반 예약으로 해야 체결됨.
         # ord_price=0,
     )
@@ -157,12 +157,15 @@ async def rsvn_buy(request: Request, rsvn_buy: RsvnBuy):
     return res
 
 
-@router.post("/cancel")
-async def cancel(request: Request, ord_orgno: int, orgn_odno: int):
-    res = trader.cancel_rsvn_request(ord_orgno=str(ord_orgno), orgn_odno=str(orgn_odno))
+@router.post("/cancel_fix")
+async def cancel(request: Request, ord_orgno: int, orgn_odno: int, method_code: str = "02", fix_price: str = 0):
+    res = trader.cancel_request(
+        ord_orgno=str(ord_orgno), orgn_odno=str(orgn_odno), method_code=method_code, fix_price=fix_price
+    )
 
+    method_code = "정정" if method_code == "01" else "취소"
     logger.inform(
-        f"Cancel order {ord_orgno} {orgn_odno} | Status {res['status_code']} | Error {res['error']}",
+        f"Cancel order {ord_orgno} {orgn_odno} with method_code {method_code} and fix_price {fix_price} | Status {res['status_code']} | Error {res['error']}",
         extra={"endpoint_name": request.url.path},
     )
 
@@ -211,6 +214,18 @@ async def get_orders(request: Request, order: Order):
 
     logger.inform(
         f"get orders from {order.rsvn_ord_start_dt} - {order.rsvn_ord_end_dt} | Status {res['status_code']} | Error {res['error']}",
+        extra={"endpoint_name": request.url.path},
+    )
+
+    return res
+
+
+@router.post("/inquire_psbl_rvsecncl")
+async def inquire_psbl_rvsecncl(request: Request, inqr_dvsn_1: str, inqr_dvsn_2: str):
+    res = trader.inquire_psbl_rvsecncl(inqr_dvsn_1=inqr_dvsn_1, inqr_dvsn_2=inqr_dvsn_2)
+
+    logger.inform(
+        f"get possible cancel quantity for {inqr_dvsn_1} {inqr_dvsn_2} | Status {res['status_code']} | Error {res['error']}",
         extra={"endpoint_name": request.url.path},
     )
 

--- a/fastapi_server/controllers/trader_controller.py
+++ b/fastapi_server/controllers/trader_controller.py
@@ -124,9 +124,9 @@ async def buy(request: Request, buy: Buy):
         # ord_price=0,
     )
 
-    text = f"""
-    f"Buy stock {buy.dict()} | Status {res['status_code']} | | output {str(res['output'])} | Error {res['error']}"
-    """
+    text = (
+        f"Buy stock {buy.dict()} | Status {res['status_code']} | | output {str(res['output'])} | Error {res['error']}"
+    )
     if res["status_code"] == "200":
         _ = slack_bot.post_message(channel_id=os.getenv("TRADE_ALARM_CHANNEL"), text=text)
 
@@ -146,9 +146,7 @@ async def rsvn_buy(request: Request, rsvn_buy: RsvnBuy):
         # ord_price=0,
     )
 
-    text = f"""
-    f"Buy stock {rsvn_buy.dict()} | Status {res['status_code']} | | output {str(res['output'])} | Error {res['error']}"
-    """
+    text = f"Buy stock {rsvn_buy.dict()} | Status {res['status_code']} | | output {str(res['output'])} | Error {res['error']}"
     if res["status_code"] == "200":
         _ = slack_bot.post_message(channel_id=os.getenv("TRADE_ALARM_CHANNEL"), text=text)
 
@@ -158,9 +156,7 @@ async def rsvn_buy(request: Request, rsvn_buy: RsvnBuy):
 
 
 @router.post("/cancel_fix")
-async def cancel(
-    request: Request, ord_orgno: int, orgn_odno: int, method_code: str = "02", fix_price: str = "0"
-):
+async def cancel(request: Request, ord_orgno: int, orgn_odno: int, method_code: str = "02", fix_price: str = "0"):
     res = trader.cancel_request(
         ord_orgno=str(ord_orgno), orgn_odno=str(orgn_odno), method_code=method_code, fix_price=fix_price
     )

--- a/fastapi_server/controllers/trader_controller.py
+++ b/fastapi_server/controllers/trader_controller.py
@@ -124,9 +124,7 @@ async def buy(request: Request, buy: Buy):
         # ord_price=0,
     )
 
-    text = (
-        f"Buy stock {buy.dict()} | Status {res['status_code']} | | output {str(res['output'])} | Error {res['error']}"
-    )
+    text = f"Buy stock {buy.dict()} | Status {res['status_code']} | output {str(res['output'])} | Error {res['error']}"
     if res["status_code"] == "200":
         _ = slack_bot.post_message(channel_id=os.getenv("TRADE_ALARM_CHANNEL"), text=text)
 
@@ -146,7 +144,7 @@ async def rsvn_buy(request: Request, rsvn_buy: RsvnBuy):
         # ord_price=0,
     )
 
-    text = f"Buy stock {rsvn_buy.dict()} | Status {res['status_code']} | | output {str(res['output'])} | Error {res['error']}"
+    text = f"Buy stock {rsvn_buy.dict()} | Status {res['status_code']} | output {str(res['output'])} | Error {res['error']}"
     if res["status_code"] == "200":
         _ = slack_bot.post_message(channel_id=os.getenv("TRADE_ALARM_CHANNEL"), text=text)
 

--- a/fastapi_server/controllers/trader_controller.py
+++ b/fastapi_server/controllers/trader_controller.py
@@ -41,6 +41,12 @@ class Buy(BaseModel):
     stock_symbol: str
     ord_qty: int
     ord_price: int
+
+
+class RsvnBuy(BaseModel):
+    stock_symbol: str
+    ord_qty: int
+    ord_price: int
     rsvn_ord_end_dt: str
 
 
@@ -129,9 +135,31 @@ async def buy(request: Request, buy: Buy):
     return res
 
 
+@router.post("/rsvn_buy")
+async def rsvn_buy(request: Request, rsvn_buy: RsvnBuy):
+    res = trader.rsvn_stock(
+        stock_code=rsvn_buy.stock_symbol,
+        ord_qty=rsvn_buy.ord_qty,
+        ord_price=rsvn_buy.ord_price,
+        rsvn_ord_end_dt=rsvn_buy.rsvn_ord_end_dt,
+        # 장전 시간외는 전날 종가를 사용하지만 공란으로 비우지말고 0을 넣으라고 하는데 그럼 안되고 일반 예약으로 해야 체결됨.
+        # ord_price=0,
+    )
+
+    text = f"""
+    f"Buy stock {rsvn_buy.dict()} | Status {res['status_code']} | | output {str(res['output'])} | Error {res['error']}"
+    """
+    if res["status_code"] == "200":
+        _ = slack_bot.post_message(channel_id=os.getenv("TRADE_ALARM_CHANNEL"), text=text)
+
+    logger.inform(text, extra={"endpoint_name": request.url.path})
+
+    return res
+
+
 @router.post("/cancel")
 async def cancel(request: Request, ord_orgno: int, orgn_odno: int):
-    res = trader.cancel_request(ord_orgno=str(ord_orgno), orgn_odno=str(orgn_odno))
+    res = trader.cancel_rsvn_request(ord_orgno=str(ord_orgno), orgn_odno=str(orgn_odno))
 
     logger.inform(
         f"Cancel order {ord_orgno} {orgn_odno} | Status {res['status_code']} | Error {res['error']}",

--- a/fastapi_server/trader.py
+++ b/fastapi_server/trader.py
@@ -135,7 +135,7 @@ class Trader:
 
         return self._request(api, data, headers)
 
-    def buy_stock(self, stock_code: str, ord_qty: int, ord_price: int, rsvn_ord_end_dt: str = ""):
+    def buy_stock(self, stock_code: str, ord_qty: int, ord_price: int):
         """
         지정가 매수.
         status_code와 에러를 반환한다.
@@ -144,8 +144,6 @@ class Trader:
             stock_code (str): 종목코드
             ord_qty (int): 주문 개수
             ord_price (int): 주문 가격
-            rsvn_ord_end_dt (str): 예약주문종료일자
-
         Returns:
             status_code (str): 상태 코드, (200 | 4xx | 5xx)
             output (dict): 주문 결과 KRX_FWDG_ORD_ORGNO(한국거래소 전송주문조직번호), ORNO(주문번호), ORD_TMD(주문시간)을 갖는다.
@@ -168,10 +166,6 @@ class Trader:
             # 주문 단가
             "ORD_UNPR": str(ord_price),
         }
-
-        # 예약주문종료일자 (미기입시 다음날 주문처리되고 예약주문은 종료됨)
-        if len(rsvn_ord_end_dt) != 0:
-            data["RSVN_ORD_END_DT"] = rsvn_ord_end_dt
 
         headers = {
             "Content-Type": "application/json",

--- a/fastapi_server/trader.py
+++ b/fastapi_server/trader.py
@@ -259,10 +259,10 @@ class Trader:
         except Exception as e:
             status_code = "5xx"
             error = str(e)
-        finally:
-            return {"status_code": status_code, "output": output, "error": error}
 
-    def cancel_request(self, ord_orgno: str, orgn_odno: str, method_code: str = "02", fix_price: int = 0):
+        return {"status_code": status_code, "output": output, "error": error}
+
+    def cancel_request(self, ord_orgno: str, orgn_odno: str, method_code: str = "02", fix_price: str = "0"):
         """
         주문당시의 영업점코드와 주문번호를 활용해 요청한 매입/매도 주문을 정정 혹은 취소한다.
         status_code와 에러를 반환한다.
@@ -273,7 +273,7 @@ class Trader:
             ord_orgno (str): 한국거래소전송주문조직번호
             orgn_odno (str): 원주문번호
             method_code (str): 정정취소 구분코드 (01: 정정, 02: 취소)
-            fix_price (int): 정정 단가 (method_code가 01일 때만 유효)
+            fix_price (str): 정정 단가 (method_code가 01일 때만 유효)
 
         Returns:
             status_code (str): 상태 코드, (200 | 4xx | 5xx)
@@ -298,7 +298,7 @@ class Trader:
             # 주문 수량 (0은 전량)
             "ORD_QTY": "0",
             # 주문 단가
-            "ORD_UNPR": fix_price if method_code == "01" else "0",
+            "ORD_UNPR": str(fix_price) if method_code == "01" else "0",
             # 잔량전부주문여부
             "QTY_ALL_ORD_YN": "Y",
         }

--- a/fastapi_server/trader.py
+++ b/fastapi_server/trader.py
@@ -138,7 +138,7 @@ class Trader:
     def buy_stock(self, stock_code: str, ord_qty: int, ord_price: int):
         """
         지정가 매수.
-        status_code와 에러를 반환한다.
+        status_code와 주문 결과를 반환한다.
 
         Args:
             stock_code (str): 종목코드

--- a/fastapi_server/trader.py
+++ b/fastapi_server/trader.py
@@ -79,7 +79,7 @@ class Trader:
         self.access_token = access_token
         os.environ["KIS_ACCESS_TOKEN"] = access_token
 
-    def buy_stock(self, stock_code: str, ord_qty: int, ord_price: int, rsvn_ord_end_dt: str = ""):
+    def rsvn_stock(self, stock_code: str, ord_qty: int, ord_price: int, rsvn_ord_end_dt: str = ""):
         """
         장전 시간외 매수를 통해 전날 종가 기준으로 예약 구매한다.
         해당 stock의 accum asset이 감당할 수 있을만큼 구매한다.
@@ -97,7 +97,7 @@ class Trader:
             error (str): 에러
 
         """
-        tr_id = os.getenv("BUY_TR_ID")
+        tr_id = os.getenv("RSVN_BUY_TR_ID")
         api = "uapi/domestic-stock/v1/trading/order-resv"
 
         data = {
@@ -116,6 +116,57 @@ class Trader:
             "SLL_BUY_DVSN_CD": "02",
             # 주문대상 잔고 구분코드 10: 현금
             "ORD_OBJT_CBLC_DVSN_CD": "10",
+        }
+
+        # 예약주문종료일자 (미기입시 다음날 주문처리되고 예약주문은 종료됨)
+        if len(rsvn_ord_end_dt) != 0:
+            data["RSVN_ORD_END_DT"] = rsvn_ord_end_dt
+
+        headers = {
+            "Content-Type": "application/json",
+            "authorization": f"Bearer {self.access_token}",
+            "appKey": self.app_key,
+            "appSecret": self.app_secret,
+            "tr_id": tr_id,
+            # 개인
+            "custtype": "P",
+            "hashkey": self.hashkey(data),
+        }
+
+        return self._request(api, data, headers)
+
+    def buy_stock(self, stock_code: str, ord_qty: int, ord_price: int, rsvn_ord_end_dt: str = ""):
+        """
+        지정가 매수.
+        status_code와 에러를 반환한다.
+
+        Args:
+            stock_code (str): 종목코드
+            ord_qty (int): 주문 개수
+            ord_price (int): 주문 가격
+            rsvn_ord_end_dt (str): 예약주문종료일자
+
+        Returns:
+            status_code (str): 상태 코드, (200 | 4xx | 5xx)
+            output (dict): 주문 결과 KRX_FWDG_ORD_ORGNO(한국거래소 전송주문조직번호), ORNO(주문번호), ORD_TMD(주문시간)을 갖는다.
+            error (str): 에러
+
+        """
+        tr_id = os.getenv("BUY_TR_ID")
+        api = "uapi/domestic-stock/v1/trading/order-cash"
+
+        data = {
+            # 계좌번호
+            "CANO": os.getenv("ACCOUNT_FRONT"),
+            "ACNT_PRDT_CD": os.getenv("ACCOUNT_REAR"),
+            # 종목번호
+            "PDNO": stock_code,
+            # 주문구분 - 지정가(00), 시장가(01), 장전 시간외(05)
+            "ORD_DVSN": "00",
+            # 주문 수량
+            "ORD_QTY": str(ord_qty),
+            # 주문 단가
+            "ORD_UNPR": str(ord_price),
         }
 
         # 예약주문종료일자 (미기입시 다음날 주문처리되고 예약주문은 종료됨)
@@ -211,21 +262,25 @@ class Trader:
         finally:
             return {"status_code": status_code, "output": output, "error": error}
 
-    def cancel_request(self, ord_orgno: str, orgn_odno: str):
+    def cancel_request(self, ord_orgno: str, orgn_odno: str, method_code: str = "02", fix_price: int = 0):
         """
-        주문당시의 영업점코드와 주문번호를 활용해 요청한 매입/매도 주문을 취소한다.
+        주문당시의 영업점코드와 주문번호를 활용해 요청한 매입/매도 주문을 정정 혹은 취소한다.
         status_code와 에러를 반환한다.
+
+        잔량 전부 주문 여부는 항상 Y로 설정해 전량 취소 혹은 정정하도록 한다. 부분 정정/취소는 미고려
 
         Args:
             ord_orgno (str): 한국거래소전송주문조직번호
             orgn_odno (str): 원주문번호
+            method_code (str): 정정취소 구분코드 (01: 정정, 02: 취소)
+            fix_price (int): 정정 단가 (method_code가 01일 때만 유효)
 
         Returns:
             status_code (str): 상태 코드, (200 | 4xx | 5xx)
             error (str): 에러
 
         """
-        tr_id = os.getenv("CANCEL_TR_ID")
+        tr_id = os.getenv("CANCEL_FIX_TR_ID")
         api = "uapi/domestic-stock/v1/trading/order-rvsecncl"
 
         data = {
@@ -239,11 +294,11 @@ class Trader:
             # 주문구분 - 지정가(00), 시장가(01)
             "ORD_DVSN": "00",
             # 정정취소 구분코드 (01: 정정, 02: 취소)
-            "RVSE_CNCL_DVSN_CD": "02",
+            "RVSE_CNCL_DVSN_CD": method_code,
             # 주문 수량 (0은 전량)
             "ORD_QTY": "0",
             # 주문 단가
-            "ORD_UNPR": "0",
+            "ORD_UNPR": fix_price if method_code == "01" else "0",
             # 잔량전부주문여부
             "QTY_ALL_ORD_YN": "Y",
         }
@@ -345,6 +400,67 @@ class Trader:
 
         return self._request(api, data, headers, method="GET")
 
+    def inquire_psbl_rvsecncl(self, inqr_dvsn_1: str, inqr_dvsn_2: str):
+        """
+        정정/취소 가능 여부 조회
+        주문당시의 영업점코드와 주문번호를 활용해 요청한 매입/매도 주문의 정정/취소 가능 여부를 조회한다.
+
+        Args:
+            inqr_dvsn_1 (str): 조회구분1 (0 주문 / 1 종목)
+            inqr_dvsn_2 (str): 조회구분2 (0 모두 / 1 매도 / 2 매수)
+
+        Returns:
+            status_code (str): 상태 코드, (200 | 4xx | 5xx)
+            output (dict): 다음 주문 결과 dict를 list로 갖는다.
+                ord_gno_brno: str    #주문채번지점번호
+                odno: str    #주문번호
+                orgn_odno: str    #원주문번호
+                ord_dvsn_name: str    #주문구분명
+                pdno: str    #상품번호
+                prdt_name: str    #상품명
+                rvse_cncl_dvsn_name: str    #정정취소구분명
+                ord_qty: str    #주문수량
+                ord_unpr: str    #주문단가
+                ord_tmd: str    #주문시각
+                tot_ccld_qty: str    #총체결수량
+                tot_ccld_amt: str    #총체결금액
+                psbl_qty: str    #가능수량
+                sll_buy_dvsn_cd: str    #매도매수구분코드
+                ord_dvsn_cd: str    #주문구분코드
+                mgco_aptm_odno: str    #운용사지정주문번호
+                excg_dvsn_cd: str    #거래소구분코드
+                excg_id_dvsn_cd: str    #거래소ID구분코드
+                excg_id_dvsn_name: str    #거래소ID구분명
+                stpm_cndt_pric: str    #스톱지정가조건가격
+                stpm_efct_occr_yn: str    #스톱지정가효력발생여부
+            error (str): 에러
+
+        """
+        tr_id = os.getenv("INQ_PSBL_CANCEL_TR_ID")
+        api = "uapi/domestic-stock/v1/trading/inquire-psbl-rvsecncl"
+
+        data = {
+            # 계좌번호
+            "CANO": os.getenv("ACCOUNT_FRONT"),
+            "ACNT_PRDT_CD": os.getenv("ACCOUNT_REAR"),
+            # 한국거래소전송주문조직번호
+            "INQR_DVSN_1": inqr_dvsn_1,
+            "INQR_DVSN_2": inqr_dvsn_2,
+        }
+
+        headers = {
+            "Content-Type": "application/json",
+            "authorization": f"Bearer {self.access_token}",
+            "appKey": self.app_key,
+            "appSecret": self.app_secret,
+            "tr_id": tr_id,
+            # 개인
+            "custtype": "P",
+            "hashkey": self.hashkey(data),
+        }
+
+        return self._request(api, data, headers, method="GET")
+
     def get_reserved_orders(self, rsvn_ord_start_dt: str, rsvn_ord_end_dt: str):
         """
         국내 예약 주문 조회
@@ -352,7 +468,7 @@ class Trader:
 
         Returns:
             status_code (str): 상태 코드, (200 | 4xx | 5xx)
-            output (dict): 주문 결과 KRX_FWDG_ORD_ORGNO(한국거래소 전송주문조직번호), ORNO(주문번호), ORD_TMD(주문시간)을 갖는다.
+            output (dict): 다음 주문 결과 dict를 list로 갖는다.
             error (str): 에러
 
         """
@@ -428,7 +544,7 @@ if __name__ == "__main__":
 
     res = trader.inquire_balance()
     #
-    # res = trader.buy_stock(
+    # res = trader.rsvn_stock(
     #     stock_code="453810",
     #     ord_qty=1,
     #     ord_price=13600


### PR DESCRIPTION
## Title
- rename nadd buy

## Description
- 예약매수만 있던 것에 매수 추가, 매도 추가
  - 단순 예약매매 말고 즉각적인 매매 가능하도록

## Linked Issues
- resolved #92 
